### PR TITLE
Fix - Wrong indicator number when remove sildes.

### DIFF
--- a/library/src/main/java/com/heinrichreimersoftware/materialintro/view/InkPageIndicator.java
+++ b/library/src/main/java/com/heinrichreimersoftware/materialintro/view/InkPageIndicator.java
@@ -173,6 +173,7 @@ public class InkPageIndicator extends View implements ViewPager.OnPageChangeList
             @Override
             public void onChanged() {
                 setPageCount(InkPageIndicator.this.viewPager.getAdapter().getCount());
+                invalidate();
             }
         });
         setCurrentPageImmediate();


### PR DESCRIPTION
When I try to remove slides through IntroActivity I found the indicator showing the wrong "dots". 

I added an invalidate in `InkPageIndicator`'s observer and fixed this.