### PR TITLE
Button function should not prevent moving past final slide

### DIFF
--- a/library/src/main/java/com/heinrichreimersoftware/materialintro/app/IntroActivity.java
+++ b/library/src/main/java/com/heinrichreimersoftware/materialintro/app/IntroActivity.java
@@ -284,10 +284,6 @@ public class IntroActivity extends AppCompatActivity {
     }
 
     private boolean canGoForward(int position, boolean notifyListeners) {
-        if (buttonNextFunction == BUTTON_NEXT_FUNCTION_NEXT && position >= getCount() - 1)
-            //Block finishing when button "next" function is not "finish".
-            return false;
-
         boolean canGoForward = (navigationPolicy == null || navigationPolicy.canGoForward(position)) &&
                 getSlide(position).canGoForward();
         if (!canGoForward && notifyListeners) {


### PR DESCRIPTION
Settings the `ButtonNextFunction `as `BUTTON_NEXT_FUNCTION_NEXT` makes it so that the final slide cannot be dismissed.
Button function should affect only what happens on pressing the button, and should not interfere with slide navigation policy.
Since `BUTTON_NEXT_FUNCTION_NEXT `makes the Next button not show on the final slide anyway, `canGoForward `does not need to be false.
(If such behavior is required where the final slide cannot be moved past, it should be defined explicitly via `NavigationPolicy`)