### PR TITLE
Add helper method to get blocked listener in frag

### DIFF
--- a/library/src/main/java/com/heinrichreimersoftware/materialintro/app/SlideFragment.java
+++ b/library/src/main/java/com/heinrichreimersoftware/materialintro/app/SlideFragment.java
@@ -18,6 +18,18 @@ public class SlideFragment extends Fragment {
         }
     }
 
+    public void addOnNavigationBlockedListener(OnNavigationBlockedListener listener) {
+        if (getActivity() instanceof IntroActivity) {
+            ((IntroActivity) getActivity()).addOnNavigationBlockedListener(listener);
+        }
+    }
+
+    public void removeOnNavigationBlockedListener(OnNavigationBlockedListener listener) {
+        if (getActivity() instanceof IntroActivity) {
+            ((IntroActivity) getActivity()).removeOnNavigationBlockedListener(listener);
+        }
+    }
+
     protected void nextSlide() {
         if (getActivity() instanceof IntroActivity) {
             ((IntroActivity) getActivity()).nextSlide();


### PR DESCRIPTION
One user scenario could be that we want to start async tasks when the
navigation is blocked. These tasks might be better fired of from the
fragment than the IntroActivity, thus listener needed in fragment.