### PR TITLE
Added methods to force navigate next and previous slide

### DIFF
--- a/library/src/main/java/com/heinrichreimersoftware/materialintro/app/IntroActivity.java
+++ b/library/src/main/java/com/heinrichreimersoftware/materialintro/app/IntroActivity.java
@@ -416,7 +416,7 @@ public class IntroActivity extends AppCompatActivity implements IntroNavigation 
     }
 
     @Override
-    public boolean goToSlide(int position) {
+    public boolean goToSlide(int position, boolean forceScroll) {
         int lastPosition = miPager.getCurrentItem();
 
         if (lastPosition >= adapter.getCount()) {
@@ -429,12 +429,12 @@ public class IntroActivity extends AppCompatActivity implements IntroNavigation 
 
         if (position > lastPosition) {
             // Go forward
-            while (newPosition < position && canGoForward(newPosition, true)) {
+            while (newPosition < position && (canGoForward(newPosition, true) || forceScroll)) {
                 newPosition++;
             }
         } else if (position < lastPosition) {
             // Go backward
-            while (newPosition > position && canGoBackward(newPosition, true)) {
+            while (newPosition > position && (canGoBackward(newPosition, true) || forceScroll)) {
                 newPosition--;
             }
         } else {
@@ -463,7 +463,13 @@ public class IntroActivity extends AppCompatActivity implements IntroNavigation 
     @Override
     public boolean nextSlide() {
         int currentItem = miPager.getCurrentItem();
-        return goToSlide(currentItem + 1);
+        return goToSlide(currentItem + 1, false);
+    }
+
+    @Override
+    public boolean forceNextSlide() {
+        int currentItem = miPager.getCurrentItem();
+        return goToSlide(currentItem + 1, true);
     }
 
     private int nextSlideAuto() {
@@ -498,22 +504,28 @@ public class IntroActivity extends AppCompatActivity implements IntroNavigation 
     @Override
     public boolean previousSlide() {
         int currentItem = miPager.getCurrentItem();
-        return goToSlide(currentItem - 1);
+        return goToSlide(currentItem - 1, false);
+    }
+
+    @Override
+    public boolean forcePreviousSlide() {
+        int currentItem = miPager.getCurrentItem();
+        return goToSlide(currentItem - 1, true);
     }
 
     @Override
     public boolean goToLastSlide() {
-        return goToSlide(getCount() - 1);
+        return goToSlide(getCount() - 1, false);
     }
 
     @Override
     public boolean goToFirstSlide() {
-        return goToSlide(0);
+        return goToSlide(0, false);
     }
 
     private void performButtonBackPress() {
         if (buttonBackFunction == BUTTON_BACK_FUNCTION_SKIP) {
-            goToSlide(getCount());
+            goToSlide(getCount(), false);
         } else if (buttonBackFunction == BUTTON_BACK_FUNCTION_BACK) {
             previousSlide();
         }
@@ -1459,7 +1471,7 @@ public class IntroActivity extends AppCompatActivity implements IntroNavigation 
     private class ButtonCtaClickListener implements View.OnClickListener {
         @Override
         public void onClick(View v) {
-            goToSlide(getCount());
+            goToSlide(getCount(), false);
         }
     }
 }

--- a/library/src/main/java/com/heinrichreimersoftware/materialintro/app/IntroNavigation.java
+++ b/library/src/main/java/com/heinrichreimersoftware/materialintro/app/IntroNavigation.java
@@ -26,14 +26,15 @@ package com.heinrichreimersoftware.materialintro.app;
 
 interface IntroNavigation {
     /**
-     * Tries to go to the given position and will stop when {@code canGoForward()} or
-     * {@code canGoBackward()} returns {@code false}.
+     * Tries to go to the given position and will obey {@code canGoForward()} or
+     * {@code canGoBackward()} if {@code forceScroll} is {@code false} returns {@code false}.
      *
      * @param position The position the pager should go to.
+     * @param forceScroll Forces scroll to the specified position
      * @return {@code true} if the pager was able to go the complete way to the given position,
      * {@code false} otherwise.
      */
-    boolean goToSlide(int position);
+    boolean goToSlide(int position, boolean forceScroll);
 
     /**
      * Tries to go to the next slide if {@code canGoForward()} returns {@code true}.
@@ -42,14 +43,28 @@ interface IntroNavigation {
      */
     boolean nextSlide();
 
+    /**
+     * Goes to the next slide even {@code canGoForward()} returns {@code true}.
+     *
+     * @return {@code true} if the pager was able to go to the next slide, {@code false} otherwise.
+     */
+    boolean forceNextSlide();
+
 
     /**
-     * Tries to go to the previous slide if {@code canGoForward()} returns {@code true}.
+     * Tries to go to the previous slide if {@code canGoBackward()} returns {@code true}.
      *
      * @return {@code true} if the pager was able to go to the previous slide, {@code false}
      * otherwise.
      */
     boolean previousSlide();
+
+    /**
+     * Goes to the previous slide even {@code canGoBackward()} returns {@code true}.
+     *
+     * @return {@code true} if the pager was able to go to the previous slide, {@code false} otherwise.
+     */
+    boolean forcePreviousSlide();
 
     /**
      * Tries to go to the last slide and will stop when {@code canGoForward()} returns

--- a/library/src/main/java/com/heinrichreimersoftware/materialintro/app/SlideFragment.java
+++ b/library/src/main/java/com/heinrichreimersoftware/materialintro/app/SlideFragment.java
@@ -58,8 +58,8 @@ public class SlideFragment extends Fragment implements IntroNavigation {
     }
 
     @Override
-    public boolean goToSlide(int position) {
-        return getIntroActivity().goToSlide(position);
+    public boolean goToSlide(int position, boolean forceScroll) {
+        return getIntroActivity().goToSlide(position, forceScroll);
     }
 
     @Override
@@ -68,8 +68,18 @@ public class SlideFragment extends Fragment implements IntroNavigation {
     }
 
     @Override
+    public boolean forceNextSlide() {
+        return getIntroActivity().forceNextSlide();
+    }
+
+    @Override
     public boolean previousSlide() {
         return getIntroActivity().previousSlide();
+    }
+
+    @Override
+    public boolean forcePreviousSlide() {
+        return getIntroActivity().forcePreviousSlide();
     }
 
     @Override


### PR DESCRIPTION
Solves #232 and adds new methods to navigate to next or previous slide if even `canGoForward` or `canGoBackward` is `true`.

There are some scenarios where this is highly required. For example:
Let's assume one the intro fragment has a login/register screen where you don't want the user to move ahead unless login/register is performed. Hence we specify `canGoForward` as false but we would want the user to move forward automatically when login/register is success, which now can be done by calling `forceNextSlide()` on the success callback of login/register logic.

Note: The reason why 2 new methods were added instead of adding boolean to the existing methods is because I didn't want to break the code for existing users as Java doesn't support default values for parameters. 